### PR TITLE
Fix 'gs; ga 1' adding all unstaged changes

### DIFF
--- a/functions/__breeze_variables.fish
+++ b/functions/__breeze_variables.fish
@@ -1,0 +1,7 @@
+function __breeze_variables
+  # This function doesn't need to do anything, we just have this file here to ensure autoloading only sets $arr & $op up once
+end
+
+# for global
+set -g -x arr ""
+set -g -x op ""

--- a/functions/ga.fish
+++ b/functions/ga.fish
@@ -1,4 +1,4 @@
-set -g -x arr ""
+__breeze_variables
 
 function __git_add -a var
     set toplevel (git rev-parse --show-toplevel)

--- a/functions/gb.fish
+++ b/functions/gb.fish
@@ -1,6 +1,4 @@
-# for global
-set -g -x arr ""
-set -g -x op ""
+__breeze_variables
 
 function __git_branch -a var
     # is numeric 

--- a/functions/gs.fish
+++ b/functions/gs.fish
@@ -1,5 +1,4 @@
-# for global
-set -g -x arr ""
+__breeze_variables
 
 function __gs
   set porcelain_res (git status --porcelain)


### PR DESCRIPTION
Without this fix, fish auto-loading is trashing my $arr, resulting in `gs; ga 1` adding all files, rather than just the first one.

> $ gs
> (autoloads gs.fish, which sets $arr="", then calls `gs`, setting $arr to the
> list of files)
> $ ga
> (autoloads ga.fish, which re-sets $arr to "", then calls `ga`, resulting in `git
> add $toplevel`)