### PR TITLE
Clean up iterating over $argv in gd

### DIFF
--- a/functions/gd.fish
+++ b/functions/gd.fish
@@ -44,17 +44,8 @@ function __gd
 end
 
 function gd
-    # space like, `gd 1 2 3`
-    # only one
-    set res (string split " " -- (string trim $argv))
-    set length (count $res)
-    if [ $length -eq 1 ]
-        __gd $argv
-        return
-    end
-
-    for i in $res
-        #echo $i
+    # Deal with arguments one-by-one
+    for i in $argv
         __gd $i
     end
 end


### PR DESCRIPTION
Hi - I don't understand what this is trying to do:

```fish
    # space like, `gd 1 2 3`
    # only one
    set res (string split " " -- (string trim $argv))
    set length (count $res)
    if [ $length -eq 1 ]
        __gd $argv
        return
    end

    for i in $res
        #echo $i
        __gd $i
    end
```

Can't it be replaced with simply this?

```fish
    # Deal with arguments one-by-one
    for i in $argv
         __gd $i
     end
```

Or do I misunderstand something?
