### PR TITLE
Add options for gco [#] and branches with hyphens

### DIFF
--- a/functions/gco.fish
+++ b/functions/gco.fish
@@ -11,7 +11,9 @@ function __git_checkout -a var
         
         set toplevel (git rev-parse --show-toplevel)
         set myarg $arr[$var]
-        git checkout $toplevel/$myarg
+        git checkout $myarg
+        # to allow gco from subdirs, use:
+        # git checkout $toplevel/$myarg
     else
         # not a number
         git checkout $var
@@ -21,6 +23,8 @@ end
 function __gco
     # number
     set res (string split "-" -- (string trim $argv))
+    # for branch names with hyphens, use:
+    # set res (string trim $argv)
     set first $res[1]
     set length (count $res)
     set last ""


### PR DESCRIPTION
If this is helpful, here are changes I've added for my use case - issues detailed here: https://github.com/shinriyo/breeze/issues/22

- gco [#] applies absolute path to branches, ie `/Users/{user}/workspace/etc` (from PR #20)
- gco splits branch names with hyphens