### PR TITLE
Add alias information to simple functions

### DIFF
--- a/functions/cdgtop.fish
+++ b/functions/cdgtop.fish
@@ -1,3 +1,3 @@
-function cdgtop
+function cdgtop --wraps cd --description 'alias cdgtop=cd (git rev-parse --show-toplevel)'
     cd (git rev-parse --show-toplevel)
 end

--- a/functions/g.fish
+++ b/functions/g.fish
@@ -1,3 +1,3 @@
-function g
+function g --wraps git --description 'alias g=git'
     git
 end

--- a/functions/gaa.fish
+++ b/functions/gaa.fish
@@ -1,3 +1,3 @@
-function gaa
+function gaa --wraps git --description 'alias gaa=git add --all'
     git add --all .
 end

--- a/functions/gap.fish
+++ b/functions/gap.fish
@@ -1,3 +1,3 @@
-function gap
+function gap --wraps git --description 'alias gap=git add -p'
     git add -p
 end

--- a/functions/gash.fish
+++ b/functions/gash.fish
@@ -1,3 +1,3 @@
-function gash
+function gash --wraps git --description 'alias gash=git stash'
     git stash
 end

--- a/functions/gasha.fish
+++ b/functions/gasha.fish
@@ -1,3 +1,3 @@
-function gasha
+function gasha --wraps git --description 'alias gasha=git stash apply'
     git stash apply
 end

--- a/functions/gashl.fish
+++ b/functions/gashl.fish
@@ -1,3 +1,3 @@
-function gashl
+function gashl --wraps git --description 'alias gashl=git stash list'
     git stash list
 end

--- a/functions/gashp.fish
+++ b/functions/gashp.fish
@@ -1,3 +1,3 @@
-function gashp
+function gashp --wraps git --description 'alias gashp=git stash pop'
     git stash pop
 end

--- a/functions/gashu.fish
+++ b/functions/gashu.fish
@@ -1,3 +1,3 @@
-function gashu
+function gashu --wraps git --description 'alias gashu=git stash --include-untracked'
     git stash --include-untracked
 end

--- a/functions/gau.fish
+++ b/functions/gau.fish
@@ -1,3 +1,3 @@
-function gau
+function gau --wraps git --description 'alias gau=git add -u'
     git add -u
 end

--- a/functions/gc.fish
+++ b/functions/gc.fish
@@ -1,3 +1,3 @@
-function gc
+function gc --wraps git --description 'alias gc=git commit'
     git commit $argv
 end

--- a/functions/gce.fish
+++ b/functions/gce.fish
@@ -1,3 +1,3 @@
-function gce
+function gce --wraps git --description 'alias gce=git clean'
     git clean $argv
 end

--- a/functions/gcef.fish
+++ b/functions/gcef.fish
@@ -1,3 +1,3 @@
-function gcef
+function gcef --wraps git --description 'alias gcef=git clean -fd'
     git clean -fd
 end

--- a/functions/gcl.fish
+++ b/functions/gcl.fish
@@ -1,3 +1,3 @@
-function gcl
+function gcl --wraps git --description 'alias gcl=git clone'
     git clone $argv
 end

--- a/functions/gcmsg.fish
+++ b/functions/gcmsg.fish
@@ -1,3 +1,3 @@
-function gcmsg
+function gcmsg --wraps git --description 'alias gcmsg=git commit -m'
     git commit -m $argv
 end

--- a/functions/gdf.fish
+++ b/functions/gdf.fish
@@ -1,3 +1,3 @@
-function gdf
+function gdf --wraps git --description 'alias gdf=git diff --'
     git diff --
 end

--- a/functions/gdnw.fish
+++ b/functions/gdnw.fish
@@ -1,3 +1,3 @@
-function gdnw
+function gdnw --wraps git --description 'alias gdnw=git diff -w --'
     git diff -w --
 end

--- a/functions/gdw.fish
+++ b/functions/gdw.fish
@@ -1,3 +1,3 @@
-function gdw
+function gdw --wraps git --description 'alias gdw=git diff --word-diff'
     git diff --word-diff $argv
 end

--- a/functions/gf.fish
+++ b/functions/gf.fish
@@ -1,3 +1,3 @@
-function gf
+function gf --wraps git --description 'alias gf=git fetch'
     git fetch
 end

--- a/functions/gfa.fish
+++ b/functions/gfa.fish
@@ -1,3 +1,3 @@
-function gf
+function gfa --wraps git --description 'alias gfa=git fetch --all'
     git fetch --all
 end

--- a/functions/gfr.fish
+++ b/functions/gfr.fish
@@ -1,3 +1,3 @@
-function gf
+function gfr --wraps git --description 'alias gfr=git fetch; and git rebase'
     git fetch; and git rebase
 end

--- a/functions/glg.fish
+++ b/functions/glg.fish
@@ -1,3 +1,3 @@
-function glg
+function glg --wraps git --description 'alias glg=git log --graph --max-count=5'
     git log --graph --max-count=5
 end

--- a/functions/gm.fish
+++ b/functions/gm.fish
@@ -1,3 +1,3 @@
-function gm
+function gm --wraps git --description 'alias gm=git merge'
     git merge $argv
 end

--- a/functions/gmff.fish
+++ b/functions/gmff.fish
@@ -1,3 +1,3 @@
-function gmff
+function gmff --wraps git --description 'alias gmff=git merge --ff'
     git merge --ff $argv
 end

--- a/functions/gmnff.fish
+++ b/functions/gmnff.fish
@@ -1,3 +1,3 @@
-function gmnff
+function gmnff --wraps git --description 'alias gmnff=git merge --no-ff'
     git merge --no-ff
 end

--- a/functions/gopen.fish
+++ b/functions/gopen.fish
@@ -1,3 +1,3 @@
-function gopen
+function gopen --wraps git --description 'alias gopen=git config --get remote.origin.url | xargs open'
     git config --get remote.origin.url | xargs open
 end

--- a/functions/gpl.fish
+++ b/functions/gpl.fish
@@ -1,3 +1,3 @@
-function gpl
-    git pull 
+function gpl --wraps git --description 'alias gpl=git pull'
+    git pull
 end

--- a/functions/gplr.fish
+++ b/functions/gplr.fish
@@ -1,3 +1,3 @@
-function gplr
+function gplr --wraps git --description 'alias gplr=git pull --rebase'
     git pull --rebase $argv
 end

--- a/functions/gps.fish
+++ b/functions/gps.fish
@@ -1,3 +1,3 @@
-function gps
+function gps --wraps git --description 'alias gps=git push'
     git push
 end

--- a/functions/gpsf.fish
+++ b/functions/gpsf.fish
@@ -1,4 +1,3 @@
-function gpsf
-        git push -f $argv
+function gpsf --wraps git --description 'alias gpsf=git push -f'
+    git push -f $argv
 end
-

--- a/functions/gr.fish
+++ b/functions/gr.fish
@@ -1,3 +1,3 @@
-function gr
+function gr --wraps git --description 'alias gr=git remote -v'
     git remote -v
 end

--- a/functions/grb.fish
+++ b/functions/grb.fish
@@ -1,3 +1,3 @@
-function grb
+function grb --wraps git --description 'alias grb=git rebase'
     git rebase
 end

--- a/functions/grbi.fish
+++ b/functions/grbi.fish
@@ -1,3 +1,3 @@
-function grbi
-    git rebase -i 
+function grbi --wraps git --description 'alias grbi=git rebase -i'
+    git rebase -i
 end

--- a/functions/grs.fish
+++ b/functions/grs.fish
@@ -1,3 +1,3 @@
-function grs
+function grs --wraps git --description 'alias grs=git reset --'
     git reset --
 end

--- a/functions/grsh.fish
+++ b/functions/grsh.fish
@@ -1,3 +1,3 @@
-function grsh
+function grsh --wraps git --description 'alias grsh=git reset --hard'
     git reset --hard
 end

--- a/functions/grsl.fish
+++ b/functions/grsl.fish
@@ -1,3 +1,3 @@
-function grsl
+function grsl --wraps git --description 'alias grsl=git reset HEAD~'
     git reset HEAD~ $argv
 end

--- a/functions/gsh.fish
+++ b/functions/gsh.fish
@@ -1,3 +1,3 @@
-function gsh
+function gsh --wraps git --description 'alias gsh=git show'
     git show
 end

--- a/functions/gt.fish
+++ b/functions/gt.fish
@@ -1,3 +1,3 @@
-function gt
+function gt --wraps git --description 'alias gt=git tag'
     git tag
 end

--- a/functions/gtop.fish
+++ b/functions/gtop.fish
@@ -1,3 +1,3 @@
-function gtop
+function gtop --wraps git --description 'alias gtop=git rev-parse --show-toplevel'
     git rev-parse --show-toplevel
 end

--- a/functions/gurl.fish
+++ b/functions/gurl.fish
@@ -1,3 +1,3 @@
-function gurl
+function gurl --wraps git --description 'alias gurl=git config --get remote.origin.url'
     git config --get remote.origin.url
 end

--- a/functions/runsv.fish
+++ b/functions/runsv.fish
@@ -1,3 +1,3 @@
-function runsv
+function runsv --wraps python --description 'alias runsv=python -m SimpleHTTPServer'
     python -m SimpleHTTPServer $argv
 end


### PR DESCRIPTION
This lets users see all the aliases (at least the simple ones 😅)
added by breeze by running [`alias`](https://fishshell.com/docs/current/cmds/alias.html).