### PR TITLE
Add `$argv` to alias functions

### DIFF
--- a/functions/g.fish
+++ b/functions/g.fish
@@ -1,3 +1,3 @@
 function g --wraps git --description 'alias g=git'
-    git
+    git $argv;
 end

--- a/functions/gaa.fish
+++ b/functions/gaa.fish
@@ -1,3 +1,3 @@
 function gaa --wraps git --description 'alias gaa=git add --all'
-    git add --all .
+    git add --all $argv;
 end

--- a/functions/gap.fish
+++ b/functions/gap.fish
@@ -1,3 +1,3 @@
 function gap --wraps git --description 'alias gap=git add -p'
-    git add -p
+    git add -p $argv;
 end

--- a/functions/gash.fish
+++ b/functions/gash.fish
@@ -1,3 +1,3 @@
 function gash --wraps git --description 'alias gash=git stash'
-    git stash
+    git stash $argv;
 end

--- a/functions/gasha.fish
+++ b/functions/gasha.fish
@@ -1,3 +1,3 @@
 function gasha --wraps git --description 'alias gasha=git stash apply'
-    git stash apply
+    git stash apply $argv;
 end

--- a/functions/gashl.fish
+++ b/functions/gashl.fish
@@ -1,3 +1,3 @@
 function gashl --wraps git --description 'alias gashl=git stash list'
-    git stash list
+    git stash list $argv;
 end

--- a/functions/gashp.fish
+++ b/functions/gashp.fish
@@ -1,3 +1,3 @@
 function gashp --wraps git --description 'alias gashp=git stash pop'
-    git stash pop
+    git stash pop $argv;
 end

--- a/functions/gashu.fish
+++ b/functions/gashu.fish
@@ -1,3 +1,3 @@
 function gashu --wraps git --description 'alias gashu=git stash --include-untracked'
-    git stash --include-untracked
+    git stash --include-untracked $argv;
 end

--- a/functions/gau.fish
+++ b/functions/gau.fish
@@ -1,3 +1,3 @@
 function gau --wraps git --description 'alias gau=git add -u'
-    git add -u
+    git add -u $argv;
 end

--- a/functions/gc.fish
+++ b/functions/gc.fish
@@ -1,3 +1,3 @@
 function gc --wraps git --description 'alias gc=git commit'
-    git commit $argv
+    git commit $argv;
 end

--- a/functions/gce.fish
+++ b/functions/gce.fish
@@ -1,3 +1,3 @@
 function gce --wraps git --description 'alias gce=git clean'
-    git clean $argv
+    git clean $argv;
 end

--- a/functions/gcef.fish
+++ b/functions/gcef.fish
@@ -1,3 +1,3 @@
 function gcef --wraps git --description 'alias gcef=git clean -fd'
-    git clean -fd
+    git clean -fd $argv;
 end

--- a/functions/gcl.fish
+++ b/functions/gcl.fish
@@ -1,3 +1,3 @@
 function gcl --wraps git --description 'alias gcl=git clone'
-    git clone $argv
+    git clone $argv;
 end

--- a/functions/gcmsg.fish
+++ b/functions/gcmsg.fish
@@ -1,3 +1,3 @@
 function gcmsg --wraps git --description 'alias gcmsg=git commit -m'
-    git commit -m $argv
+    git commit -m $argv;
 end

--- a/functions/gdf.fish
+++ b/functions/gdf.fish
@@ -1,3 +1,3 @@
 function gdf --wraps git --description 'alias gdf=git diff --'
-    git diff --
+    git diff -- $argv;
 end

--- a/functions/gdnw.fish
+++ b/functions/gdnw.fish
@@ -1,3 +1,3 @@
 function gdnw --wraps git --description 'alias gdnw=git diff -w --'
-    git diff -w --
+    git diff -w -- $argv;
 end

--- a/functions/gdw.fish
+++ b/functions/gdw.fish
@@ -1,3 +1,3 @@
 function gdw --wraps git --description 'alias gdw=git diff --word-diff'
-    git diff --word-diff $argv
+    git diff --word-diff $argv;
 end

--- a/functions/gf.fish
+++ b/functions/gf.fish
@@ -1,3 +1,3 @@
 function gf --wraps git --description 'alias gf=git fetch'
-    git fetch
+    git fetch $argv;
 end

--- a/functions/gfa.fish
+++ b/functions/gfa.fish
@@ -1,3 +1,3 @@
 function gfa --wraps git --description 'alias gfa=git fetch --all'
-    git fetch --all
+    git fetch --all $argv;
 end

--- a/functions/gfr.fish
+++ b/functions/gfr.fish
@@ -1,3 +1,3 @@
 function gfr --wraps git --description 'alias gfr=git fetch; and git rebase'
-    git fetch; and git rebase
+    git fetch; and git rebase $argv;
 end

--- a/functions/glg.fish
+++ b/functions/glg.fish
@@ -1,3 +1,3 @@
 function glg --wraps git --description 'alias glg=git log --graph --max-count=5'
-    git log --graph --max-count=5
+    git log --graph --max-count=5 $argv;
 end

--- a/functions/gm.fish
+++ b/functions/gm.fish
@@ -1,3 +1,3 @@
 function gm --wraps git --description 'alias gm=git merge'
-    git merge $argv
+    git merge $argv;
 end

--- a/functions/gmff.fish
+++ b/functions/gmff.fish
@@ -1,3 +1,3 @@
 function gmff --wraps git --description 'alias gmff=git merge --ff'
-    git merge --ff $argv
+    git merge --ff $argv;
 end

--- a/functions/gmnff.fish
+++ b/functions/gmnff.fish
@@ -1,3 +1,3 @@
 function gmnff --wraps git --description 'alias gmnff=git merge --no-ff'
-    git merge --no-ff
+    git merge --no-ff $argv;
 end

--- a/functions/gopen.fish
+++ b/functions/gopen.fish
@@ -1,3 +1,3 @@
 function gopen --wraps git --description 'alias gopen=git config --get remote.origin.url | xargs open'
-    git config --get remote.origin.url | xargs open
+    git config --get remote.origin.url $argv | xargs open;
 end

--- a/functions/gpl.fish
+++ b/functions/gpl.fish
@@ -1,3 +1,3 @@
 function gpl --wraps git --description 'alias gpl=git pull'
-    git pull
+    git pull $argv;
 end

--- a/functions/gplr.fish
+++ b/functions/gplr.fish
@@ -1,3 +1,3 @@
 function gplr --wraps git --description 'alias gplr=git pull --rebase'
-    git pull --rebase $argv
+    git pull --rebase $argv;
 end

--- a/functions/gps.fish
+++ b/functions/gps.fish
@@ -1,3 +1,3 @@
 function gps --wraps git --description 'alias gps=git push'
-    git push
+    git push $argv;
 end

--- a/functions/gpsf.fish
+++ b/functions/gpsf.fish
@@ -1,3 +1,3 @@
 function gpsf --wraps git --description 'alias gpsf=git push -f'
-    git push -f $argv
+    git push -f $argv;
 end

--- a/functions/gr.fish
+++ b/functions/gr.fish
@@ -1,3 +1,3 @@
 function gr --wraps git --description 'alias gr=git remote -v'
-    git remote -v
+    git remote -v $argv;
 end

--- a/functions/grb.fish
+++ b/functions/grb.fish
@@ -1,3 +1,3 @@
 function grb --wraps git --description 'alias grb=git rebase'
-    git rebase
+    git rebase $argv;
 end

--- a/functions/grbi.fish
+++ b/functions/grbi.fish
@@ -1,3 +1,3 @@
 function grbi --wraps git --description 'alias grbi=git rebase -i'
-    git rebase -i
+    git rebase -i $argv;
 end

--- a/functions/grs.fish
+++ b/functions/grs.fish
@@ -1,3 +1,3 @@
 function grs --wraps git --description 'alias grs=git reset --'
-    git reset --
+    git reset -- $argv;
 end

--- a/functions/grsh.fish
+++ b/functions/grsh.fish
@@ -1,3 +1,3 @@
 function grsh --wraps git --description 'alias grsh=git reset --hard'
-    git reset --hard
+    git reset --hard $argv;
 end

--- a/functions/grsl.fish
+++ b/functions/grsl.fish
@@ -1,3 +1,3 @@
 function grsl --wraps git --description 'alias grsl=git reset HEAD~'
-    git reset HEAD~ $argv
+    git reset HEAD~ $argv;
 end

--- a/functions/gsh.fish
+++ b/functions/gsh.fish
@@ -1,3 +1,3 @@
 function gsh --wraps git --description 'alias gsh=git show'
-    git show
+    git show $argv;
 end

--- a/functions/gt.fish
+++ b/functions/gt.fish
@@ -1,3 +1,3 @@
 function gt --wraps git --description 'alias gt=git tag'
-    git tag
+    git tag $argv;
 end

--- a/functions/gtop.fish
+++ b/functions/gtop.fish
@@ -1,3 +1,3 @@
 function gtop --wraps git --description 'alias gtop=git rev-parse --show-toplevel'
-    git rev-parse --show-toplevel
+    git rev-parse --show-toplevel $argv;
 end

--- a/functions/gurl.fish
+++ b/functions/gurl.fish
@@ -1,3 +1,3 @@
 function gurl --wraps git --description 'alias gurl=git config --get remote.origin.url'
-    git config --get remote.origin.url
+    git config --get remote.origin.url $argv;
 end

--- a/functions/runsv.fish
+++ b/functions/runsv.fish
@@ -1,3 +1,3 @@
 function runsv --wraps python --description 'alias runsv=python -m SimpleHTTPServer'
-    python -m SimpleHTTPServer $argv
+    python -m SimpleHTTPServer $argv;
 end


### PR DESCRIPTION
Add `$argv` at end of git alias functions in order to be able to append
commands or flags to all aliases, which means that stuff like
`gps -u origin <branch>` now works as expected.